### PR TITLE
Feature/software update

### DIFF
--- a/bin/alevinMtxTo10x.py
+++ b/bin/alevinMtxTo10x.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+# Read the results of Alevin and write outputs to a .mtx file readable by tools
+# expecting 10X outputs. Adapted from
+# https://github.com/k3yavi/vpolo/blob/master/vpolo/alevin/parser.py 
+
+from __future__ import print_function
+from collections import defaultdict
+from struct import Struct
+import pandas as pd
+import gzip
+import sys
+import os
+from scipy.io import mmread,mmwrite
+from scipy.sparse import *
+from shutil import copyfile
+import pathlib
+import numpy as np
+import argparse
+
+parser = argparse.ArgumentParser(description='Convert Alevin outputs to 10X .mtx.')
+parser.add_argument('alevin_out', help = 'Alevin output directory')
+parser.add_argument('mtx_out', help = 'Output directory for converted results')
+parser.add_argument('--cell_prefix', dest='cell_prefix', default='', help = 'Prefix to apply to cell barcodes')
+args = parser.parse_args() 
+
+alevin_out=args.alevin_out
+mtx_out=args.mtx_out
+cell_prefix=args.cell_prefix
+
+# Run some checks in the Alevin output
+
+if not os.path.isdir(alevin_out):
+    print("{} is not a directory".format( alevin_out ))
+    sys.exit(1)
+
+alevin_out = os.path.join(alevin_out, "alevin")
+
+if not os.path.exists(alevin_out):
+    print("{} directory doesn't exist".format( alevin_out ))
+    sys.exit(1)
+
+quant_file = os.path.join(alevin_out, "quants_mat.mtx.gz")
+if not os.path.exists(quant_file):
+    print("quant file {} doesn't exist".format( quant_file ))
+    sys.exit(1)
+
+cb_file = os.path.join(alevin_out, "quants_mat_rows.txt")
+if not os.path.exists(cb_file):
+    print("quant file's index: {} doesn't exist".format( cb_file ))
+    sys.exit(1)
+
+gene_file = os.path.join(alevin_out, "quants_mat_cols.txt")
+if not os.path.exists(gene_file):
+    print("quant file's header: {} doesn't exist".format( gene_file))
+    sys.exit(1)
+
+# Read gene and cell labels, apply cell prefix
+
+cb_names = [cell_prefix + s for s in pd.read_csv(cb_file, header=None)[0].values]
+gene_names = pd.read_csv(gene_file, header=None)[0].values
+umi_counts = mmread( quant_file )
+    
+# Write outputs to a .mtx file readable by tools expecting 10X outputs.
+# Barcodes file works as-is, genes need to be two-column, duplicating the
+# identifiers. Matrix itself needs to have genes by row, so we transpose. 
+
+pathlib.Path(mtx_out).mkdir(parents=True, exist_ok=True)
+mmwrite('%s/matrix.mtx' % mtx_out, umi_counts.transpose()) 
+
+genes_frame = pd.DataFrame([ gene_names, gene_names]).transpose()
+genes_frame.to_csv(path_or_buf='%s/genes.tsv' % mtx_out, index=False, sep="\t", header = False)
+
+with open('%s/barcodes.tsv' % mtx_out, 'w') as f:
+    f.write("\n".join(cb_names))    
+    f.write("\n")    

--- a/envs/alevin.yml
+++ b/envs/alevin.yml
@@ -1,6 +1,6 @@
 name: salmon
 dependencies:
-  - salmon=0.13.1
+  - salmon=0.14.1
   - bioconductor-dropletutils
   - r-gridextra
   - r-ggplot2

--- a/envs/dropletutils.yml
+++ b/envs/dropletutils.yml
@@ -1,4 +1,4 @@
 name: dropletutils
 dependencies:
-  - bioconductor-dropletutils=1.0.3
-  - dropletutils-scripts=0.0.2
+  - bioconductor-dropletutils=1.4.2
+  - dropletutils-scripts=0.0.3

--- a/main.nf
+++ b/main.nf
@@ -209,7 +209,7 @@ process alevin {
 
     salmon alevin -l ${params.salmon.libType} -1 \$(ls barcodes*.fastq.gz | tr '\\n' ' ') -2 \$(ls cdna*.fastq.gz | tr '\\n' ' ') \
         ${barcodeConfig} -i ${indexDir} -p ${task.cpus} -o ${runId}_tmp --tgMap ${transcriptToGene} --whitelist pre_whitelist.txt \
-        --forceCells \$(cat pre_whitelist.txt | wc -l | tr -d '\\n')
+        --forceCells \$(cat pre_whitelist.txt | wc -l | tr -d '\\n') --dumpMtx
  
     mv ${runId}_tmp ${runId}
     """

--- a/main.nf
+++ b/main.nf
@@ -261,8 +261,6 @@ ALEVIN_RESULTS_FOR_QC
 
 process droplet_qc_plot{
     
-    publishDir "$resultsRoot/alevin/qc", mode: 'copy', overwrite: true
-    
     conda "${baseDir}/envs/alevin.yml"
     
     memory { 10.GB * task.attempt }
@@ -334,6 +332,7 @@ process rds_to_mtx{
 ALEVIN_RESULTS_FOR_OUTPUT
     .join(ALEVIN_MTX_FOR_OUTPUT)
     .join(NONEMPTY_MTX)
+    .join(ALEVIN_QC_PLOTS)
     .set{ COMPILED_RESULTS }
 
 process compile_results{
@@ -341,7 +340,7 @@ process compile_results{
     publishDir "$resultsRoot/alevin", mode: 'copy', overwrite: true
     
     input:
-        set val(runId), file('raw_alevin'), file(rawBarcodeFreq), file(countsMtx), file(countsMtxNonempty) from COMPILED_RESULTS
+        set val(runId), file('raw_alevin'), file(rawBarcodeFreq), file(countsMtx), file(countsMtxNonempty), file(qcPlot) from COMPILED_RESULTS
 
     output:
         set val(runId), file("$runId") into RESULTS_FOR_COUNTING
@@ -349,6 +348,8 @@ process compile_results{
     """
         mkdir -p raw_alevin/alevin/mtx
         cp -P $countsMtx $countsMtxNonempty raw_alevin/alevin/mtx 
+        mkdir -p raw_alevin/alevin/qc
+        cp -P $qcPlot raw_alevin/alevin/qc
         cp -P raw_alevin $runId
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -234,7 +234,7 @@ process alevin_to_mtx {
     maxRetries 20
 
     input:
-        set val(runId), file(alevinResult) from ALEVIN_RESULTS_FOR_PROCESSING
+        set val(runId), file(alevinResult), file(rawBarcodeFreq) from ALEVIN_RESULTS_FOR_PROCESSING
 
     output:
         set val(runId), file("counts_mtx") into ALEVIN_MTX
@@ -270,13 +270,13 @@ process droplet_qc_plot{
     maxRetries 20
 
     input:
-        set val(runId), file(alevinResult), file(raw_bc_freq), file(mtx) from ALEVIN_QC_INPUTS
+        set val(runId), file(alevinResult), file(rawBarcodeFreq), file(mtx) from ALEVIN_QC_INPUTS
 
     output:
         set val(runId), file("${runId}.png") into ALEVIN_QC_PLOTS
 
     """
-    dropletBarcodePlot.R $raw_bc_freq $mtx $runId ${runId}.png
+    dropletBarcodePlot.R $rawBarcodeFreq $mtx $runId ${runId}.png
     """ 
 }
 
@@ -341,7 +341,7 @@ process compile_results{
     publishDir "$resultsRoot/alevin", mode: 'copy', overwrite: true
     
     input:
-        set val(runId), file('raw_alevin'), file(countsMtx), file(countsMtxNonempty) from COMPILED_RESULTS
+        set val(runId), file('raw_alevin'), file(rawBarcodeFreq), file(countsMtx), file(countsMtxNonempty) from COMPILED_RESULTS
 
     output:
         set val(runId), file("$runId") into RESULTS_FOR_COUNTING

--- a/main.nf
+++ b/main.nf
@@ -240,7 +240,7 @@ process alevin_to_mtx {
         set val(runId), file("counts_mtx") into ALEVIN_MTX
 
     """
-    alevinToMtx.py --cell_prefix ${runId}- $alevinResult counts_mtx
+    alevinMtxTo10x.py --cell_prefix ${runId}- $alevinResult counts_mtx
     """ 
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,7 +27,7 @@ params {
         nIters = 1000
         testAmbient = 'FALSE'
         filterEmpty = 'TRUE'
-        filterFdr = '0.05'
+        filterFdr = '0.01'
     }
 
     '10xv2' {


### PR DESCRIPTION
This PR applies updates from DropletUtils and Alevin.

The newer Alevin outputs MTX format matrices directly, so we can use that. There's still some processing to make the output look like that of 10x for easy parsing (e.g. matrix is in wrong orientation), but it's quicker to use this than parse the old binary format. I've created a new alevinMtxTo10x.py script, deprecating the old alevinToMtx.py.

I discovered that DropletUtils' emptyDrops() method does not operate correctly with non-integer values. dropletutils-scripts=0.0.3 incorporates a fix to round to integers prior to empty droplet detection. We will need to re-process droplet experiments.

Code changes tested successfully in test environment.