### PR TITLE
Feature/hca download

### DIFF
--- a/envs/atlas-fastq-provider.yml
+++ b/envs/atlas-fastq-provider.yml
@@ -1,3 +1,3 @@
 name: atlas-fastq-provider
 dependencies:
-  - atlas-fastq-provider=0.1.8
+  - atlas-fastq-provider=0.1.9

--- a/envs/atlas-fastq-provider.yml
+++ b/envs/atlas-fastq-provider.yml
@@ -1,3 +1,3 @@
 name: atlas-fastq-provider
 dependencies:
-  - atlas-fastq-provider=0.1.6
+  - atlas-fastq-provider=0.1.8

--- a/envs/atlas-fastq-provider.yml
+++ b/envs/atlas-fastq-provider.yml
@@ -1,3 +1,4 @@
 name: atlas-fastq-provider
 dependencies:
   - atlas-fastq-provider=0.1.9
+  - hca=6.4.0

--- a/envs/hca.yml
+++ b/envs/hca.yml
@@ -1,0 +1,3 @@
+name: hca
+dependencies:
+  - hca=6.4.0

--- a/main.nf
+++ b/main.nf
@@ -29,7 +29,7 @@ REFERENCE_GTF = Channel.fromPath( referenceGtf, checkIfExists: true )
 
 // Read URIs from SDRF, generate target file names, and barcode locations
 
-if ( params.containsKey('hca_uuid') ){
+if ( params.fields.containsKey('hca_uuid') ){
     SDRF_FOR_FASTQS
         .map{ row-> tuple(row["${params.fields.run}"], row["${params.fields.hca_uuid}"], row["${params.fields.hca_version}"], row["${params.fields.cdna_uri}"], row["${params.fields.cell_barcode_uri}"],  row["${params.fields.cell_barcode_size}"], row["${params.fields.umi_barcode_size}"], row["${params.fields.end}"], row["${params.fields.cell_count}"]) }
         .set { FASTQ_RUNS }

--- a/main.nf
+++ b/main.nf
@@ -29,80 +29,46 @@ REFERENCE_GTF = Channel.fromPath( referenceGtf, checkIfExists: true )
 
 // Read URIs from SDRF, generate target file names, and barcode locations
 
-if ( params.fields.containsKey('hca_uuid') ){
-    SDRF_FOR_FASTQS
-        .map{ row-> tuple(row["${params.fields.run}"], row["${params.fields.hca_uuid}"], row["${params.fields.hca_version}"], row["${params.fields.cdna_uri}"], row["${params.fields.cell_barcode_uri}"],  row["${params.fields.cell_barcode_size}"], row["${params.fields.umi_barcode_size}"], row["${params.fields.end}"], row["${params.fields.cell_count}"]) }
-        .set { FASTQ_RUNS }
-  
-    // Use the HCA DSS client to retrieve the fastqs
- 
-    process hca_download_fastqs{
-        
-        conda "${baseDir}/envs/hca.yml"
-        
-        maxForks params.maxConcurrentDownloads
-        time { 1.hour * task.attempt }
+SDRF_FOR_FASTQS
+    .map{ row-> tuple(row["${params.fields.run}"], row["${params.fields.cdna_uri}"], row["${params.fields.cell_barcode_uri}"], file(row["${params.fields.cdna_uri}"]).getName(), file(row["${params.fields.cell_barcode_uri}"]).getName(), row["${params.fields.cell_barcode_size}"], row["${params.fields.umi_barcode_size}"], row["${params.fields.end}"], row["${params.fields.cell_count}"]) }
+    .set { FASTQ_RUNS }
 
-        errorStrategy { task.attempt<=10 ? 'retry' : 'finish' } 
-        
-        input:
-            set runId, hcaUUID, hcaVersion, cdnaFastqFile, barcodesFastqFile, val(barcodeLength), val(umiLength), val(end), val(cellCount) from FASTQ_RUNS
+// Call the download script to retrieve run fastqs
 
-        output:
-            set val(runId), file("${cdnaFastqFile}"), file("${barcodesFastqFile}"), val(barcodeLength), val(umiLength), val(end), val(cellCount) into DOWNLOADED_FASTQS
+process download_fastqs {
+    
+    conda "${baseDir}/envs/atlas-fastq-provider.yml"
+    
+    maxForks params.maxConcurrentDownloads
+    time { 1.hour * task.attempt }
 
-        """
-        hca dss download --bundle-uuid $hcaUUID --version $hcaVersion --download-dir . --replica aws --no-metadata --data-filter ${cdnaFastqFile}        
-        hca dss download --bundle-uuid $hcaUUID --version $hcaVersion --download-dir . --replica aws --no-metadata --data-filter ${barcodesFastqFile}        
+    errorStrategy { task.attempt<=10 ? 'retry' : 'finish' } 
+    
+    input:
+        set runId, cdnaFastqURI, barcodesFastqURI, cdnaFastqFile, barcodesFastqFile, val(barcodeLength), val(umiLength), val(end), val(cellCount) from FASTQ_RUNS
 
-        """
-    }
- 
-}else{
+    output:
+        set val(runId), file("${cdnaFastqFile}"), file("${barcodesFastqFile}"), val(barcodeLength), val(umiLength), val(end), val(cellCount) into DOWNLOADED_FASTQS
 
-    SDRF_FOR_FASTQS
-        .map{ row-> tuple(row["${params.fields.run}"], row["${params.fields.cdna_uri}"], row["${params.fields.cell_barcode_uri}"], file(row["${params.fields.cdna_uri}"]).getName(), file(row["${params.fields.cell_barcode_uri}"]).getName(), row["${params.fields.cell_barcode_size}"], row["${params.fields.umi_barcode_size}"], row["${params.fields.end}"], row["${params.fields.cell_count}"]) }
-        .set { FASTQ_RUNS }
-
-    // Call the download script to retrieve run fastqs
-
-    process download_fastqs {
-        
-        conda "${baseDir}/envs/atlas-fastq-provider.yml"
-        
-        maxForks params.maxConcurrentDownloads
-        time { 1.hour * task.attempt }
-
-        errorStrategy { task.attempt<=10 ? 'retry' : 'finish' } 
-        
-        input:
-            set runId, cdnaFastqURI, barcodesFastqURI, cdnaFastqFile, barcodesFastqFile, val(barcodeLength), val(umiLength), val(end), val(cellCount) from FASTQ_RUNS
-
-        output:
-            set val(runId), file("${cdnaFastqFile}"), file("${barcodesFastqFile}"), val(barcodeLength), val(umiLength), val(end), val(cellCount) into DOWNLOADED_FASTQS
-
-        """
-            if [ -n "$manualDownloadFolder" ] && [ -e $manualDownloadFolder/${cdnaFastqFile} ] && [ -e $manualDownloadFolder/${barcodesFastqFile} ]; then
-               ln -s $manualDownloadFolder/${cdnaFastqFile} ${cdnaFastqFile}
-               ln -s $manualDownloadFolder/${barcodesFastqFile} ${barcodesFastqFile}
-            elif [ -n "$manualDownloadFolder" ] && [ -e $manualDownloadFolder/${cdnaFastqFile} ] && [ ! -e $manualDownloadFolder/${barcodesFastqFile} ]; then
-                echo 'cDNA file $cdnaFastqFile is available locally, but barcodes file $barcodesFastqFile is not 1>&2
-                exit 2    
-            elif [ -n "$manualDownloadFolder" ] && [ ! -e $manualDownloadFolder/${cdnaFastqFile} ] && [ -e $manualDownloadFolder/${barcodesFastqFile} ]; then
-                echo 'cDNA file $cdnaFastqFile is not available locally, but barcodes file $barcodesFastqFile is 1>&2
-                exit 3    
-            else
-                confPart=''
-                if [ -e "$NXF_TEMP/atlas-fastq-provider/download_config.sh" ]; then
-                    confPart=" -c $NXF_TEMP/atlas-fastq-provider/download_config.sh"
-                fi 
-                fetchFastq.sh -f ${cdnaFastqURI} -t ${cdnaFastqFile} -m ${params.downloadMethod} \$confPart
-                fetchFastq.sh -f ${barcodesFastqURI} -t ${barcodesFastqFile} -m ${params.downloadMethod} \$confPart
-            fi
-        """
-    }
-
-
+    """
+        if [ -n "$manualDownloadFolder" ] && [ -e $manualDownloadFolder/${cdnaFastqFile} ] && [ -e $manualDownloadFolder/${barcodesFastqFile} ]; then
+           ln -s $manualDownloadFolder/${cdnaFastqFile} ${cdnaFastqFile}
+           ln -s $manualDownloadFolder/${barcodesFastqFile} ${barcodesFastqFile}
+        elif [ -n "$manualDownloadFolder" ] && [ -e $manualDownloadFolder/${cdnaFastqFile} ] && [ ! -e $manualDownloadFolder/${barcodesFastqFile} ]; then
+            echo 'cDNA file $cdnaFastqFile is available locally, but barcodes file $barcodesFastqFile is not 1>&2
+            exit 2    
+        elif [ -n "$manualDownloadFolder" ] && [ ! -e $manualDownloadFolder/${cdnaFastqFile} ] && [ -e $manualDownloadFolder/${barcodesFastqFile} ]; then
+            echo 'cDNA file $cdnaFastqFile is not available locally, but barcodes file $barcodesFastqFile is 1>&2
+            exit 3    
+        else
+            confPart=''
+            if [ -e "$NXF_TEMP/atlas-fastq-provider/download_config.sh" ]; then
+                confPart=" -c $NXF_TEMP/atlas-fastq-provider/download_config.sh"
+            fi 
+            fetchFastq.sh -f ${cdnaFastqURI} -t ${cdnaFastqFile} -m ${params.downloadMethod} \$confPart
+            fetchFastq.sh -f ${barcodesFastqURI} -t ${barcodesFastqFile} -m ${params.downloadMethod} \$confPart
+        fi
+    """
 }
 
 // Group read files by run name, or by technical replicate group if specified


### PR DESCRIPTION
This PR has ended up being a lot smaller than I thought it would be ;-).

I was going to add logic here to call the HCA download client directly. As it is, I pushed that logic in to the atlas fastq provider (see https://github.com/ebi-gene-expression-group/atlas-fastq-provider/pull/1). The HCA download URIs passed to this pipeline are recognisable by that tool, contain the HCA UUIDs and versions, and are handled automatically. So the only change here is to add the newer version of the downloader with that functionality.