### PR TITLE
Make libtype protocol specific and add 5prime

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -170,13 +170,13 @@ process alevin_config {
 
             // Non-standard barcode config is supplied as a custom method
 
-            if ( "${canonicalProtocol.barcodeLength}" != barcodeLength || "${canonicalProtocol.umiLength}" != umiLength || "${canonicalProtocol.end}" != end ){
+            if ( alevinType == 'custom' || "${canonicalProtocol.barcodeLength}" != barcodeLength || "${canonicalProtocol.umiLength}" != umiLength || "${canonicalProtocol.end}" != end ){
                 barcodeConfig = "--barcodeLength ${barcodeLength} --umiLength ${umiLength} --end ${end}" 
 
             }else{
                 barcodeConfig = "--$alevinType"
             }
-            
+            barcodeConfig = "-l ${canonicalProtocol.libType} $barcodeConfig" 
         }
 
         """
@@ -212,7 +212,7 @@ process alevin {
         set val(runId), file("${runId}"),  file("${runId}/alevin/raw_cb_frequency.txt") into ALEVIN_RESULTS
 
     """
-    salmon alevin -l ${params.salmon.libType} -1 \$(ls barcodes*.fastq.gz | tr '\\n' ' ') -2 \$(ls cdna*.fastq.gz | tr '\\n' ' ') \
+    salmon alevin -1 \$(ls barcodes*.fastq.gz | tr '\\n' ' ') -2 \$(ls cdna*.fastq.gz | tr '\\n' ' ') \
         ${barcodeConfig} -i ${indexDir} -p ${task.cpus} -o ${runId}_tmp --tgMap ${transcriptToGene} --dumpFeatures --keepCBFraction 1 \
         --freqThreshold ${params.minCbFreq} --dumpMtx
     

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,6 +28,7 @@ params {
         testAmbient = 'FALSE'
         filterEmpty = 'TRUE'
         filterFdr = '0.01'
+        libType = 'ISR'
     }
 
     '10xv2' {
@@ -35,6 +36,7 @@ params {
         barcodeLength = 16
         umiLength = 10
         end = '5'
+        libType = 'ISR'
     }
 
     'drop-seq' {
@@ -42,6 +44,7 @@ params {
         barcodeLength = 12
         umiLength = 8
         end = '5'
+        libType = 'ISR'
     }
     
     'seq-well' {
@@ -49,6 +52,7 @@ params {
         barcodeLength = 12
         umiLength = 8
         end = '5'
+        libType = 'ISR'
     }
 
     '10xv3' {
@@ -56,10 +60,18 @@ params {
         barcodeLength = 16
         umiLength = 12
         end = '5'
+        libType = 'ISR'
+    }
+    
+    '10x5prime' {
+        alevinType = 'custom'
+        barcodeLength = 16
+        umiLength = 10
+        end = '5'
+        libType = 'ISF'
     }
 
     salmon {
-        libType = 'ISR'
         index {
             kmerSize = 31
         }


### PR DESCRIPTION
This PR makes libType protocol-specific to allow for 5prime data. https://github.com/COMBINE-lab/salmon/issues/439 suggests this will be the only change required in the Alevin call, but I'll check e.g. mapping rate when we get the first example. 

See https://salmon.readthedocs.io/en/latest/alevin.html#using-alevin and https://salmon.readthedocs.io/en/latest/salmon.html#what-s-this-libtype for background on this parameter. 