### PR TITLE
Add a check on the read length for droplet quantification

### DIFF
--- a/bin/check_barcode_read.sh
+++ b/bin/check_barcode_read.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+usage() { echo "Usage: $0 [-r <gzipped read file>] [-u UMI length] [-b cell barcode length] [-n number of reads to test]" 1>&2; }
+
+r=
+u=
+b=
+n=1000
+
+while getopts ":r:u:b:n:" o; do
+    case "${o}" in
+        r)
+            r=${OPTARG}
+            ;;
+        u)
+            u=${OPTARG}
+            ;;
+        b)
+            b=${OPTARG}
+            ;;
+        n)
+            n=${OPTARG}
+            ;;
+        *)
+            usage
+            exit 0
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${r}" ] || [ -z "${u}" ] || [ -z "${b}" ] || [ -z "${n}" ]; then
+    usage
+    exit 1
+fi
+
+if [ ! -e "$r" ]; then
+    echo "Read file $r does not exist" 1>&2
+    exit 1
+fi
+
+# Calculate lenths of first n reads
+
+echo "Checking $n reads"
+
+lengths=$(zcat $r | \
+    head -n $((4 * $n)) | \
+    sed -n '2~4p' | \
+    awk '{print length()}' | \
+    sort -r | uniq)
+
+# Find number of unque lengths
+
+nLengths=$(echo -e "$lengths" | wc -l)
+if [ "$nLengths" == 1 ]; then
+    qualifier='all'
+else
+    qualifier='some'
+fi
+
+# Find longest read
+
+longest=$(echo -e "$lengths" | head -n 1)
+
+# Reads should be at least the UMI + CB length
+
+targetLength=$(($u + $b))
+
+# Print warnings for fishy things, die for big issues
+
+if [ "$nLengths" -gt 1 ]; then
+    echo "WARNING: UMI/ barcode reads are of variable length" 1>&2
+fi
+
+if [ "$longest" -gt "$targetLength" ]; then
+    echo "WARNING: $qualifier UMI/ barcode reads in $r are longer than UMI + cell barcode (=$targetLength), max length: $longest. This happens with sequencer run-on, but make sure you're sure of the barcode configuration" 1>&2
+elif [ "$longest" -lt "$targetLength" ]; then
+    echo "[ERROR} No reads in $r meet UMI + cell barcode length threshold of $targetLength (max length: $longest), these reads cannot pass to droplet quantification." 1>&2
+    exit 1
+else
+    echo "[SUCCESS: $qualifier reads in $r match UMI/ cell barcode length threshold of $targetLength (max length: $longest)"
+fi

--- a/bin/check_barcode_read.sh
+++ b/bin/check_barcode_read.sh
@@ -73,10 +73,10 @@ if [ "$nLengths" -gt 1 ]; then
 fi
 
 if [ "$longest" -gt "$targetLength" ]; then
-    echo "WARNING: $qualifier UMI/ barcode reads in $r are longer than UMI + cell barcode (=$targetLength), max length: $longest. This happens with sequencer run-on, but make sure you're sure of the barcode configuration" 1>&2
+    echo "WARNING: $qualifier UMI/ barcode reads in $(basename $r) are longer than UMI + cell barcode (=$targetLength), max length: $longest. This happens with sequencer run-on, but make sure you're sure of the barcode configuration" 1>&2
 elif [ "$longest" -lt "$targetLength" ]; then
-    echo "[ERROR} No reads in $r meet UMI + cell barcode length threshold of $targetLength (max length: $longest), these reads cannot pass to droplet quantification." 1>&2
+    echo "[ERROR} No reads in $(basename $r) meet UMI + cell barcode length threshold of $targetLength (max length: $longest), these reads cannot pass to droplet quantification." 1>&2
     exit 1
 else
-    echo "[SUCCESS: $qualifier reads in $r match UMI/ cell barcode length threshold of $targetLength (max length: $longest)"
+    echo "[SUCCESS: $qualifier reads in $(basename $r) match UMI/ cell barcode length threshold of $targetLength (max length: $longest)"
 fi

--- a/main.nf
+++ b/main.nf
@@ -185,20 +185,20 @@ process alevin_config {
             exit 1
         fi
 
-        echo -n "$barcodeConfig"
-
         # Also check barcode read lengths and return non-0 if they're not what they should be
 
         targetLen=\$(($umiLength + $barcodeLength))
         barcodesGood=0
         set +e
         while read -r l; do
-            check_barcode_read.sh -r \$(readlink -f \$l) -b $barcodeLength -u $umiLength -n 1000000
+            check_barcode_read.sh -r \$(readlink -f \$l) -b $barcodeLength -u $umiLength -n 1000000 1>&2
             if [ \$? -ne 0 ]; then
                 barcodesGood=1
             fi
         done <<< "\$(ls barcodes*.fastq.gz)"
         set -e
+        
+        echo -n "$barcodeConfig"
         exit \$barcodesGood
         """
 }

--- a/main.nf
+++ b/main.nf
@@ -191,13 +191,14 @@ process alevin_config {
 
         targetLen=\$(($umiLength + $barcodeLength))
         barcodesGood=0
+        set +e
         while read -r l; do
-            readLen=\$(zcat \$l | sed '2q;d' | tr -d '\\n' | wc -m)
-            if [ "\$readLen" -lt "\$targetLen" ]; then
-                echo "\$l has reads of length \$readLen, which is not what we expected with barcode length of $barcodeLength and a UMI length of $umiLength" 1>&2
+            check_barcode_read.sh -r \$l -b $barcodeLength -u $umiLength -n 1000000
+            if [ $? -ne 0 ]; then
                 barcodesGood=1
             fi
         done <<< \$(ls barcodes*.fastq.gz)
+        set -e
         exit \$barcodesGood
         """
 }

--- a/main.nf
+++ b/main.nf
@@ -193,7 +193,7 @@ process alevin_config {
         barcodesGood=0
         set +e
         while read -r l; do
-            check_barcode_read.sh -r \$l -b $barcodeLength -u $umiLength -n 1000000
+            check_barcode_read.sh -r \$(readlink -f \$l) -b $barcodeLength -u $umiLength -n 1000000
             if [ \$? -ne 0 ]; then
                 barcodesGood=1
             fi

--- a/main.nf
+++ b/main.nf
@@ -197,7 +197,7 @@ process alevin_config {
             if [ \$? -ne 0 ]; then
                 barcodesGood=1
             fi
-        done <<< \$(ls barcodes*.fastq.gz)
+        done <<< "\$(ls barcodes*.fastq.gz)"
         set -e
         exit \$barcodesGood
         """

--- a/main.nf
+++ b/main.nf
@@ -194,7 +194,7 @@ process alevin_config {
         set +e
         while read -r l; do
             check_barcode_read.sh -r \$l -b $barcodeLength -u $umiLength -n 1000000
-            if [ $? -ne 0 ]; then
+            if [ \$? -ne 0 ]; then
                 barcodesGood=1
             fi
         done <<< \$(ls barcodes*.fastq.gz)

--- a/main.nf
+++ b/main.nf
@@ -186,6 +186,19 @@ process alevin_config {
         fi
 
         echo -n "$barcodeConfig"
+
+        # Also check barcode read lengths and return non-0 if they're not what they should be
+
+        targetLen=\$(($umiLength + $barcodeLength))
+        barcodesGood=0
+        while read -r l; do
+            readLen=\$(zcat \$l | sed '2q;d' | tr -d '\\n' | wc -m)
+            if [ "\$readLen" -lt "\$targetLen" ]; then
+                echo "\$l has reads of length \$readLen, which is not what we expected with barcode length of $barcodeLength and a UMI length of $umiLength" 1>&2
+                barcodesGood=1
+            fi
+        done <<< \$(ls barcodes*.fastq.gz)
+        exit \$barcodesGood
         """
 }
 


### PR DESCRIPTION
This PR adds an explicit check on barcode file read length, requiring it to be at least the combined cell barcode and UMI length. I believe we can expect longer reads when sequencers 'run on', so I don't want to make the matching exact. This will stop things proceeding to Alevin and failing there mysteriously as currently happens.

**Edit:** Following some internal discussion we agreed that we could expect variable length reads, so taking the first read only is likely to create difficulties. For that reason I switched things to scan the top of a fastq file and only error if none of those reads match criteria. 