### PR TITLE
Allow for SRA file as source of read files

### DIFF
--- a/envs/atlas-fastq-provider.yml
+++ b/envs/atlas-fastq-provider.yml
@@ -1,5 +1,5 @@
 name: atlas-fastq-provider
 dependencies:
-  - atlas-fastq-provider=0.2.2
+  - atlas-fastq-provider=0.2.3
   - sra-tools
   - hca=7.0.1

--- a/envs/atlas-fastq-provider.yml
+++ b/envs/atlas-fastq-provider.yml
@@ -1,5 +1,5 @@
 name: atlas-fastq-provider
 dependencies:
-  - atlas-fastq-provider=0.2.1
+  - atlas-fastq-provider=0.2.2
   - sra-tools
   - hca=7.0.1

--- a/envs/atlas-fastq-provider.yml
+++ b/envs/atlas-fastq-provider.yml
@@ -1,5 +1,5 @@
 name: atlas-fastq-provider
 dependencies:
-  - atlas-fastq-provider=0.2.0
+  - atlas-fastq-provider=0.2.1
   - sra-tools
   - hca=7.0.1

--- a/envs/atlas-fastq-provider.yml
+++ b/envs/atlas-fastq-provider.yml
@@ -1,4 +1,5 @@
 name: atlas-fastq-provider
 dependencies:
-  - atlas-fastq-provider=0.1.15
+  - atlas-fastq-provider=0.2.0
+  - sra-tools
   - hca=7.0.1

--- a/main.nf
+++ b/main.nf
@@ -76,7 +76,12 @@ process download_fastqs {
                 confPart=" -c $NXF_TEMP/atlas-fastq-provider/download_config.sh"
             fi 
             fetchFastq.sh -f ${cdnaFastqURI} -t ${cdnaFastqFile} -m ${params.downloadMethod} \$confPart
-            fetchFastq.sh -f ${barcodesFastqURI} -t ${barcodesFastqFile} -m ${params.downloadMethod} \$confPart
+            
+            # Allow for the first download also having produced the second output already
+
+            if [ ! -e ${barcodesFastqFile} ]; then
+                fetchFastq.sh -f ${barcodesFastqURI} -t ${barcodesFastqFile} -m ${params.downloadMethod} \$confPart
+            fi
         fi
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -74,7 +74,10 @@ process download_fastqs {
             confPart=''
             if [ -e "$NXF_TEMP/atlas-fastq-provider/download_config.sh" ]; then
                 confPart=" -c $NXF_TEMP/atlas-fastq-provider/download_config.sh"
-            fi 
+            fi
+            # Stop fastq downloader from testing different methods -assume the control workflow has done that 
+            export NOPROBE=1
+        
             fetchFastq.sh -f ${cdnaFastqURI} -t ${cdnaFastqFile} -m ${params.downloadMethod} \$confPart
             
             # Allow for the first download also having produced the second output already

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,7 +17,7 @@ conda {
 
 params {
     
-    downloadMethod = 'wget'
+    downloadMethod = 'auto'
     maxConcurrentDownloads = 10
     minMappingRate = 40
     minCbFreq = 10    


### PR DESCRIPTION
Just change the way the fastq file downloader is called to allow for SRA file download. We're just passing through the sra/ prefixed URIs defined at the config stage, but we need to account for a single call (i.e. the download and unpacking of the SRA file) producing both of the file outputs we need.

See also:

- https://github.com/ebi-gene-expression-group/atlas-fastq-provider/pull/6
- https://github.com/ebi-gene-expression-group/scxa-control-workflow/pull/28