### PR TITLE
Warn when Alevin reports low mapping

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -237,7 +237,13 @@ process alevin {
     salmon alevin ${barcodeConfig} -1 \$(ls barcodes*.fastq.gz | tr '\\n' ' ') -2 \$(ls cdna*.fastq.gz | tr '\\n' ' ') \
         -i ${indexDir} -p ${task.cpus} -o ${runId}_tmp --tgMap ${transcriptToGene} --dumpFeatures --keepCBFraction 1 \
         --freqThreshold ${params.minCbFreq} --dumpMtx
-    
+
+    min_mapping=\$(grep "percent_mapped" ${runId}_tmp/aux_info/meta_info.json | sed 's/,//g' | awk -F': ' '{print \$2}' | sort -n | head -n 1)   
+    if [ "\${min_mapping%.*}" -lt "${params.minMappingRate}" ]; then
+        echo "Minimum mapping rate (\$min_mapping) is less than the specified threshold of ${params.minMappingRate}" 1>&2
+        exit 1 
+    fi
+ 
     mv ${runId}_tmp ${runId}
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,7 +19,7 @@ params {
     
     downloadMethod = 'auto'
     maxConcurrentDownloads = 10
-    minMappingRate = 40
+    minMappingRate = 30
     minCbFreq = 10    
 
     'emptyDrops' {


### PR DESCRIPTION
A recent incident where low mapping caused by mis-annotation of library type caused a low cell detection number in Alevin highlighted the fact that we should really be screening for issues with the alignment rate. 

The rates in the above example were extremely low (<5%). Typically we get rates at at least ~40% when I've checked, but I suggest we start with a flag of 30% to actually trigger an error. 