### PR TITLE
Feature/add info for whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The workflow requires as input:
  - A Nextflow configuration file describing the data in the tabular samples table
  - A string specifying whether the experiment is snRNA or scRNA
  - An output directory for results
- - A whitelist for 10XV2 and 10XV3 to filter barcodes. (__Note__: The 10XV3 whitelist needs to be downladed [here](https://raw.githubusercontent.com/10XGenomics/cellranger/master/lib/python/cellranger/barcodes/translation/3M-february-2018.txt.gz) and placed here `w_droplet_quantification/whitelist/3M-february-2018_onecollum.txt` )  
+ - A whitelist for 10XV2 and 10XV3 to filter barcodes. (__Note__: The 10XV3 whitelist needs to be downladed [here](https://raw.githubusercontent.com/10XGenomics/cellranger/master/lib/python/cellranger/barcodes/translation/3M-february-2018.txt.gz) and placed here `w_droplet_quantification/whitelist/3M-february-2018_onecollum.txt`)  
 
 ### Transcript to gene map
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The workflow requires as input:
  - A Nextflow configuration file describing the data in the tabular samples table
  - A string specifying whether the experiment is snRNA or scRNA
  - An output directory for results
+ - A whitelist for 10XV2 and 10XV3 to filter barcodes. (__Note__: The 10XV3 whitelist needs to be downladed [here](https://raw.githubusercontent.com/10XGenomics/cellranger/master/lib/python/cellranger/barcodes/translation/3M-february-2018.txt.gz) and placed here `w_droplet_quantification/whitelist/3M-february-2018_onecollum.txt` )  
 
 ### Transcript to gene map
 


### PR DESCRIPTION
This PR adds information about the whitelist required to run alevin-fry for 10XV2 and 10XV3 experiments. The 10XV2 whitelist is included in the repo, but 10XV3 whitelist need to be downloaded seperatly.