### PR TITLE
Update atlas-fastsq-provider

### DIFF
--- a/envs/atlas-fastq-provider.yml
+++ b/envs/atlas-fastq-provider.yml
@@ -1,6 +1,6 @@
 name: atlas-fastq-provider
 dependencies:
   - jq
-  - atlas-fastq-provider=0.4.7
+  - atlas-fastq-provider=0.4.8
   - sra-tools
   - hca=7.0.1


### PR DESCRIPTION
This change brings atlas-fastq-provider to the most recent version, 0.4.8, which has updates on the HCA fetch tool.